### PR TITLE
Remove termos de afiliacao link

### DIFF
--- a/afiliados.html
+++ b/afiliados.html
@@ -146,7 +146,6 @@
 
     <footer class="bg-[#181818] text-center py-6 mt-12">
         <div class="text-sm space-x-4 mb-4">
-            <a href="#" class="hover:text-spotify-green">Termos de Afiliação</a>
             <a href="#" class="hover:text-spotify-green">Suporte</a>
             <a href="#" class="hover:text-spotify-green">Políticas da CED BRASIL</a>
         </div>


### PR DESCRIPTION
## Summary
- remove the "Termos de Afiliação" footer link from the afiliados page

## Testing
- `python3 -m py_compile cursos.py`

------
https://chatgpt.com/codex/tasks/task_e_68419b3967fc832686c20a0a71a87e0e