### PR TITLE
Improve demo login and fix external links

### DIFF
--- a/assinatura.html
+++ b/assinatura.html
@@ -349,7 +349,7 @@
             </p>
             <i class="fab fa-whatsapp text-6xl spotify-green mb-6"></i>
             <p class="text-gray-400 text-sm">Aguarde nosso contato! Se precisar de algo, use o botão abaixo para falar conosco.</p>
-            <a href="https://wa.me/5561986660241" target="_blank" class="mt-8 inline-block bg-spotify-green text-black font-extrabold px-8 py-4 rounded-full text-lg hover-bg-spotify-green-darker transition duration-300 shadow-lg transform hover:scale-105">
+            <a href="https://wa.me/5561986660241" target="_blank" rel="noopener" class="mt-8 inline-block bg-spotify-green text-black font-extrabold px-8 py-4 rounded-full text-lg hover-bg-spotify-green-darker transition duration-300 shadow-lg transform hover:scale-105">
                 <i class="fab fa-whatsapp text-2xl mr-2"></i> Falar com Consultor
             </a>
         </div>
@@ -369,8 +369,8 @@
             </div>
             <div class="flex flex-col md:flex-row justify-center items-center gap-6 mb-10">
                 <div class="flex space-x-6">
-                    <a href="https://www.facebook.com/people/CED-Brasil/61575889016332/" target="_blank" class="hover:text-spotify-green transition duration-300" aria-label="Facebook"><i class="fab fa-facebook-f text-2xl"></i></a>
-                    <a href="https://instagram.com/cedbrasill" target="_blank" class="hover:text-spotify-green transition duration-300" aria-label="Instagram"><i class="fab fa-instagram text-2xl"></i></a>
+                    <a href="https://www.facebook.com/people/CED-Brasil/61575889016332/" target="_blank" rel="noopener" class="hover:text-spotify-green transition duration-300" aria-label="Facebook"><i class="fab fa-facebook-f text-2xl"></i></a>
+                    <a href="https://instagram.com/cedbrasill" target="_blank" rel="noopener" class="hover:text-spotify-green transition duration-300" aria-label="Instagram"><i class="fab fa-instagram text-2xl"></i></a>
                 </div>
                 <p class="text-sm">Telefone: (61) 98666-0241</p>
             </div>

--- a/index.html
+++ b/index.html
@@ -46,6 +46,16 @@
       .hover-bg-spotify-green-darker:hover {
         background-color: #1aa34a; /* Verde um pouco mais escuro para hover */
       }
+
+      /* Tema claro */
+      body.light-theme {
+        filter: invert(1) hue-rotate(180deg);
+        background-color: #ffffff;
+      }
+      body.light-theme img,
+      body.light-theme video {
+        filter: invert(1) hue-rotate(180deg);
+      }
       .section-title {
         font-size: 2.8rem; /* Título maior para seções */
         font-weight: 700;
@@ -224,6 +234,9 @@
                 <a href="https://ead.cedbrasilia.com.br" class="bg-spotify-green text-black px-6 py-3 rounded-full hover-bg-spotify-green-darker transition duration-300 text-base font-semibold shadow-md">Área do Aluno</a>
                 <a href="https://www.cedbrasilia.com.br/parceiros" class="bg-spotify-green text-black px-6 py-3 rounded-full hover-bg-spotify-green-darker transition duration-300 text-base font-semibold shadow-md">Vire Parceiro</a>
             </nav>
+            <button id="themeToggle" class="text-yellow-400 text-2xl mr-4" aria-label="Alternar tema">
+                <i class="fas fa-moon"></i>
+            </button>
             <button id="mobileMenuButton" class="md:hidden focus:outline-none text-white">
                 <i class="fas fa-bars text-2xl"></i>
             </button>
@@ -236,6 +249,9 @@
             <a href="#contato" class="block px-6 py-3 hover:bg-[#282828] hover:text-spotify-green transition duration-300 text-lg">Contato</a>
             <a href="https://ead.cedbrasilia.com.br" class="block mx-6 my-3 bg-spotify-green text-black text-center px-6 py-3 rounded-full hover-bg-spotify-green-darker transition duration-300 text-base font-semibold shadow-md">Área do Aluno</a>
             <a href="https://www.cedbrasilia.com.br/parceiros" class="block mx-6 my-3 bg-spotify-green text-black text-center px-6 py-3 rounded-full hover-bg-spotify-green-darker transition duration-300 text-base font-semibold shadow-md">Vire Parceiro</a>
+            <button id="mobileThemeToggle" class="block w-full mx-6 my-3 text-yellow-400 text-left text-lg" aria-label="Alternar tema">
+                <i class="fas fa-moon"></i> Tema
+            </button>
         </div>
     </header>
 
@@ -508,7 +524,7 @@
                     <div class="mt-8 text-center text-gray-400">
                         <p class="mb-4 text-lg font-semibold text-white">Fale conosco diretamente:</p>
                         <div class="flex flex-col sm:flex-row justify-center gap-6">
-                            <a href="https://wa.me/5561986660241" target="_blank" class="bg-spotify-green text-black font-extrabold px-8 py-4 rounded-full text-lg hover-bg-spotify-green-darker transition duration-300 shadow-lg transform hover:scale-105 flex items-center justify-center">
+                            <a href="https://wa.me/5561986660241" target="_blank" rel="noopener" class="bg-spotify-green text-black font-extrabold px-8 py-4 rounded-full text-lg hover-bg-spotify-green-darker transition duration-300 shadow-lg transform hover:scale-105 flex items-center justify-center">
                                 <i class="fab fa-whatsapp text-2xl mr-2"></i> Chamar no WhatsApp
                             </a>
                             <a href="mailto:contato@cedbrasil.com.br" class="border-2 border-spotify-green text-spotify-green font-semibold px-8 py-4 rounded-full text-lg hover:bg-spotify-green hover:text-black transition duration-300 shadow-lg transform hover:scale-105 flex items-center justify-center">
@@ -551,8 +567,8 @@
                 <div>
                     <h4 class="text-xl font-semibold text-white mb-4">Conecte-se</h4>
                     <div class="flex justify-center md:justify-start space-x-6 mb-4">
-                        <a href="https://www.facebook.com/people/CED-Brasil/61575889016332/" target="_blank" class="hover:text-spotify-green transition duration-300" aria-label="Facebook"><i class="fab fa-facebook-f text-2xl"></i></a>
-                        <a href="https://instagram.com/cedbrasill" target="_blank" class="hover:text-spotify-green transition duration-300" aria-label="Instagram"><i class="fab fa-instagram text-2xl"></i></a>
+                        <a href="https://www.facebook.com/people/CED-Brasil/61575889016332/" target="_blank" rel="noopener" class="hover:text-spotify-green transition duration-300" aria-label="Facebook"><i class="fab fa-facebook-f text-2xl"></i></a>
+                        <a href="https://instagram.com/cedbrasill" target="_blank" rel="noopener" class="hover:text-spotify-green transition duration-300" aria-label="Instagram"><i class="fab fa-instagram text-2xl"></i></a>
                     </div>
                     <p class="text-sm">Telefone: (61) 98666-0241</p>
                 </div>
@@ -582,7 +598,7 @@
         <a href="#cursos" class="w-full bg-spotify-green text-black font-extrabold px-6 py-3 rounded-full text-base text-center hover-bg-spotify-green-darker transition duration-300 shadow-lg transform hover:scale-105">
             Quero me Inscrever! <i class="fas fa-arrow-right ml-2"></i>
         </a>
-        <a href="https://wa.me/5561986660241" target="_blank" class="w-full border-2 border-spotify-green text-spotify-green font-semibold px-6 py-3 rounded-full text-base text-center hover:bg-spotify-green hover:text-black transition duration-300 shadow-lg transform hover:scale-105">
+        <a href="https://wa.me/5561986660241" target="_blank" rel="noopener" class="w-full border-2 border-spotify-green text-spotify-green font-semibold px-6 py-3 rounded-full text-base text-center hover:bg-spotify-green hover:text-black transition duration-300 shadow-lg transform hover:scale-105">
             Fale no WhatsApp <i class="fab fa-whatsapp ml-2"></i>
         </a>
     </div>
@@ -601,6 +617,46 @@
           icon.classList.remove("fa-bars");
           icon.classList.add("fa-times");
         }
+      });
+
+      // Theme Toggle
+      function applyTheme(isLight) {
+        document.body.classList.toggle("light-theme", isLight);
+        const desktopIcon = document.getElementById("themeToggle").querySelector("i");
+        const mobileIcon = document.getElementById("mobileThemeToggle")?.querySelector("i");
+        if (isLight) {
+          desktopIcon.classList.remove("fa-moon");
+          desktopIcon.classList.add("fa-sun");
+          if (mobileIcon) {
+            mobileIcon.classList.remove("fa-moon");
+            mobileIcon.classList.add("fa-sun");
+          }
+        } else {
+          desktopIcon.classList.remove("fa-sun");
+          desktopIcon.classList.add("fa-moon");
+          if (mobileIcon) {
+            mobileIcon.classList.remove("fa-sun");
+            mobileIcon.classList.add("fa-moon");
+          }
+        }
+      }
+
+      const storedTheme = localStorage.getItem("theme") === "light";
+      applyTheme(storedTheme);
+
+      document.getElementById("themeToggle").addEventListener("click", () => {
+        const isLight = !document.body.classList.contains("light-theme");
+        localStorage.setItem("theme", isLight ? "light" : "dark");
+        applyTheme(isLight);
+      });
+
+      document.getElementById("mobileThemeToggle")?.addEventListener("click", () => {
+        const isLight = !document.body.classList.contains("light-theme");
+        localStorage.setItem("theme", isLight ? "light" : "dark");
+        applyTheme(isLight);
+        mobileMenu.classList.add("hidden");
+        mobileMenuButton.querySelector("i").classList.remove("fa-times");
+        mobileMenuButton.querySelector("i").classList.add("fa-bars");
       });
 
       // Smooth scroll for navigation links

--- a/parceiros.html
+++ b/parceiros.html
@@ -22,6 +22,16 @@
       .spotify-green { color: #1db954; }
       .bg-spotify-green { background-color: #1db954; }
       .hover-bg-spotify-green-darker:hover { background-color: #1aa34a; }
+
+      /* Tema claro */
+      body.light-theme {
+        filter: invert(1) hue-rotate(180deg);
+        background-color: #ffffff;
+      }
+      body.light-theme img,
+      body.light-theme video {
+        filter: invert(1) hue-rotate(180deg);
+      }
       .section-title {
         font-size: 2.8rem;
         font-weight: 700;
@@ -59,6 +69,9 @@
                 <a href="index.html" class="hover:text-spotify-green transition text-lg">Início</a>
                 <a href="https://ead.cedbrasilia.com.br" class="hover:text-spotify-green transition text-lg">Área do Aluno</a>
             </nav>
+            <button id="themeToggle" class="text-yellow-400 text-2xl mr-4" aria-label="Alternar tema">
+                <i class="fas fa-moon"></i>
+            </button>
             <button id="mobileMenuButton" class="md:hidden focus:outline-none text-white">
                 <i class="fas fa-bars text-2xl"></i>
             </button>
@@ -66,13 +79,16 @@
         <div id="mobileMenu" class="hidden md:hidden bg-[#181818] py-2 border-t border-gray-700">
             <a href="index.html" class="block px-6 py-3 hover:bg-[#282828] hover:text-spotify-green transition text-lg">Início</a>
             <a href="https://ead.cedbrasilia.com.br" class="block px-6 py-3 hover:bg-[#282828] hover:text-spotify-green transition text-lg">Área do Aluno</a>
+            <button id="mobileThemeToggle" class="block w-full px-6 py-3 text-yellow-400 text-left text-lg" aria-label="Alternar tema">
+                <i class="fas fa-moon"></i> Tema
+            </button>
         </div>
     </header>
 
     <main class="flex-grow">
         <section class="text-center py-20 px-6 bg-cover bg-center" style="background-image: linear-gradient(rgba(18,18,18,0.85), rgba(18,18,18,0.85)), url('https://placehold.co/1600x900/101010/1DB954?text=CED+BRASIL+Afiliados');">
             <h1 class="section-title">Torne-se um <span class="spotify-green">Parceiro Oficial</span></h1>
-            <p class="section-subtitle">Ganhe comissões promovendo cursos profissionalizantes com certificado válido em todo o Brasil</p>
+            <p class="section-subtitle">Ganhe Dinheiro Vendendo nossos cursos profissionalizantes com certificado válido em todo o Brasil <span class="spotify-green">GRATUITAMENTE</span></p>
             <a href="https://dashboard.kiwify.com/join/affiliate/zhTcssre" class="inline-block bg-spotify-green text-black font-bold px-8 py-4 rounded-full text-xl hover-bg-spotify-green-darker transition shadow-lg">Quero Me Tornar Parceiro/a</a>
         </section>
 
@@ -136,11 +152,29 @@
                             <p class="text-gray-400 text-sm">Receba 80% de comissão em todos os produtos!</p>
                         </div>
                     </div>
-                    <div class="card flex items-start space-x-4">
-                        <i class="fas fa-bullhorn text-3xl spotify-green mt-1"></i>
-                        <div>
-                            <h3 class="text-xl font-semibold mb-2">Página de Vendas Gratuita</h3>
-                            <p class="text-gray-400 text-sm">Nos da CED criamos para você uma página de vendas/funil 100% gratuito para divulgar seus produtos.</p>
+                      <div class="card flex items-start space-x-4">
+                          <i class="fas fa-star text-3xl spotify-green mt-1"></i>
+                          <div>
+                              <h3 class="text-xl font-semibold mb-2">Produtos de alta qualidade</h3>
+                              <p class="text-gray-400 text-sm">Cursos com excelente reputação para facilitar suas vendas.</p>
+                          </div>
+                      </div>
+                      <div class="card flex items-start space-x-4">
+                          <i class="fas fa-eye text-3xl spotify-green mt-1"></i>
+                          <div>
+                              <h3 class="text-xl font-semibold mb-2">Conta de Demonstração Gratuita</h3>
+                              <p class="text-gray-400 text-sm">Experimente a plataforma antes de indicar.</p>
+                              <button class="text-spotify-green underline mt-2" onclick="toggleDemoInfo()">Ver mais</button>
+                              <div id="demoInfo" class="mt-3 hidden">
+                                  <button onclick="loginDemoAccount()" class="inline-block bg-spotify-green text-black font-bold px-4 py-2 rounded hover-bg-spotify-green-darker transition shadow">Acessar conta teste</button>
+                              </div>
+                          </div>
+                      </div>
+                      <div class="card flex items-start space-x-4">
+                          <i class="fas fa-bullhorn text-3xl spotify-green mt-1"></i>
+                          <div>
+                              <h3 class="text-xl font-semibold mb-2">Página de Vendas Gratuita</h3>
+                              <p class="text-gray-400 text-sm">Nos da CED criamos para você uma página de vendas/funil 100% gratuito para divulgar seus produtos.</p>
                         </div>
                     </div>
                 </div>
@@ -149,11 +183,40 @@
                 </div>
             </div>
         </section>
+
+        <section class="py-16 bg-[#181818]">
+            <div class="container mx-auto px-6 text-center">
+                <h2 class="section-title">Links Úteis para Parceiros</h2>
+                <p class="section-subtitle">Fique por dentro das novidades e tenha acesso aos materiais de divulgação.</p>
+                <div class="flex flex-col md:flex-row justify-center gap-6 mt-8">
+                    <a href="https://drive.google.com/drive/folders/16pQ8SdgwrlvVJa5HLN3eIY2zjO1XlyBI?usp=sharing" target="_blank" rel="noopener" class="inline-flex items-center bg-spotify-green text-black font-bold px-6 py-3 rounded-full text-lg hover-bg-spotify-green-darker transition shadow-lg">
+                        <i class="fas fa-folder-open mr-2"></i> Materiais de Divulgação
+                    </a>
+                    <a href="https://chat.whatsapp.com/ELLrXpwBVY6Km9rnZKx1fZ" target="_blank" rel="noopener" class="inline-flex items-center bg-green-600 text-white font-bold px-6 py-3 rounded-full text-lg hover:bg-green-500 transition shadow-lg">
+                        <i class="fab fa-whatsapp mr-2"></i> Grupo de Parceiros
+                    </a>
+                    <a href="https://whatsapp.com/channel/0029VbBCJsV3QxS9Hdo6102Y" target="_blank" rel="noopener" class="inline-flex items-center bg-green-600 text-white font-bold px-6 py-3 rounded-full text-lg hover:bg-green-500 transition shadow-lg">
+                        <i class="fas fa-bullhorn mr-2"></i> Canal de Atualizações
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <section class="py-16 bg-[#0A0A0A]">
+            <div class="container mx-auto px-6 text-center">
+                <h2 class="text-2xl font-bold mb-6">Ficou alguma dúvida? Fale com o nosso suporte agora!</h2>
+                <a href="https://wa.me/5561986660241" target="_blank" rel="noopener" class="inline-flex items-center bg-spotify-green text-black font-extrabold px-8 py-4 rounded-full text-lg hover-bg-spotify-green-darker transition shadow-lg transform hover:scale-105">
+                    <i class="fab fa-whatsapp text-2xl mr-2"></i> Suporte via WhatsApp
+                </a>
+            </div>
+        </section>
     </main>
 
     <footer class="bg-[#181818] text-center py-6 mt-12">
-        <div class="text-sm space-x-4 mb-4">
-            <a href="#" class="hover:text-spotify-green">Suporte</a>
+        <div class="mb-6">
+            <a href="https://wa.me/5561986660241" target="_blank" rel="noopener" class="inline-flex items-center border-2 border-spotify-green text-spotify-green font-semibold px-6 py-3 rounded-full text-sm sm:text-base hover:bg-spotify-green hover:text-black transition duration-300 shadow-lg transform hover:scale-105">
+                <i class="fab fa-whatsapp mr-2"></i> Suporte
+            </a>
         </div>
         <div class="max-w-4xl mx-auto text-left text-sm space-y-2 text-gray-300">
             <h4 class="text-xl font-semibold text-white mb-2 text-center">📚 Políticas da CED BRASIL</h4>
@@ -182,7 +245,50 @@
       icon.classList.add('fa-times');
     }
   });
-  document.getElementById('currentYear').textContent = new Date().getFullYear();
+  function applyTheme(isLight) {
+    document.body.classList.toggle('light-theme', isLight);
+    const desktopIcon = document.getElementById('themeToggle').querySelector('i');
+    const mobileIcon = document.getElementById('mobileThemeToggle')?.querySelector('i');
+    if (isLight) {
+      desktopIcon.classList.remove('fa-moon');
+      desktopIcon.classList.add('fa-sun');
+      if (mobileIcon) {
+        mobileIcon.classList.remove('fa-moon');
+        mobileIcon.classList.add('fa-sun');
+      }
+    } else {
+      desktopIcon.classList.remove('fa-sun');
+      desktopIcon.classList.add('fa-moon');
+      if (mobileIcon) {
+        mobileIcon.classList.remove('fa-sun');
+        mobileIcon.classList.add('fa-moon');
+      }
+    }
+  }
+  const storedTheme = localStorage.getItem('theme') === 'light';
+  applyTheme(storedTheme);
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    const isLight = !document.body.classList.contains('light-theme');
+    localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    applyTheme(isLight);
+  });
+    document.getElementById('mobileThemeToggle')?.addEventListener('click', () => {
+      const isLight = !document.body.classList.contains('light-theme');
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      applyTheme(isLight);
+      mobileMenu.classList.add('hidden');
+      mobileMenuButton.querySelector('i').classList.remove('fa-times');
+      mobileMenuButton.querySelector('i').classList.add('fa-bars');
+    });
+
+    function toggleDemoInfo() {
+      document.getElementById('demoInfo').classList.toggle('hidden');
+    }
+
+    function loginDemoAccount() {
+      window.open('https://ead.cedbrasilia.com.br/index.php?pag=entrar&token=344dd9f9-4235-11f0-8cdc-0eecf9347bc9', '_blank', 'noopener');
+    }
+    document.getElementById('currentYear').textContent = new Date().getFullYear();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use direct token link for demo account in partners page
- add `rel="noopener"` to remaining external links in signup page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841af1d238c83268b8fbfd013e98799