### PR TITLE
Improve stock tables

### DIFF
--- a/afiliados.html
+++ b/afiliados.html
@@ -62,6 +62,13 @@
         transform: translateY(-6px);
         box-shadow: 0 10px 20px rgba(0,200,83,0.15);
       }
+      .estoque-table td:first-child {
+        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==');
+        background-repeat: no-repeat;
+        background-position: left center;
+        background-size: 24px 24px;
+        padding-left: 32px;
+      }
     </style>
 </head>
 <body class="antialiased flex flex-col min-h-screen">
@@ -197,7 +204,7 @@
             <div class="container mx-auto px-6">
                 <h2 class="section-title">Produtos em estoque</h2>
                 <div class="overflow-x-auto">
-                    <table class="min-w-full text-left text-gray-300">
+                    <table class="min-w-full text-left text-gray-300 estoque-table">
                         <thead>
                             <tr class="border-b border-gray-700">
                                 <th class="px-6 py-3 text-spotify-green">Nome</th>

--- a/parceiros.html
+++ b/parceiros.html
@@ -62,6 +62,13 @@
         transform: translateY(-6px);
         box-shadow: 0 10px 20px rgba(0,200,83,0.15);
       }
+      .estoque-table td:first-child {
+        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==');
+        background-repeat: no-repeat;
+        background-position: left center;
+        background-size: 24px 24px;
+        padding-left: 32px;
+      }
     </style>
 </head>
 <body class="antialiased flex flex-col min-h-screen">
@@ -197,7 +204,7 @@
             <div class="container mx-auto px-6">
                 <h2 class="section-title">Produtos em estoque</h2>
                 <div class="overflow-x-auto">
-                    <table class="min-w-full text-left text-gray-300">
+                    <table class="min-w-full text-left text-gray-300 estoque-table">
                         <thead>
                             <tr class="border-b border-gray-700">
                                 <th class="px-6 py-3 text-spotify-green">Nome</th>


### PR DESCRIPTION
## Summary
- show image background on stock product tables for affiliates and partners pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684350295e7c8326b4a4051cbe4917b7