### PR TITLE
Fix Kiwify logo and correct hero images

### DIFF
--- a/afiliados.html
+++ b/afiliados.html
@@ -35,6 +35,9 @@
       body.light-theme img.no-invert {
         filter: none !important;
       }
+      body.light-theme .keep-colors {
+        filter: invert(1) hue-rotate(180deg);
+      }
       .section-title {
         font-size: 2.8rem;
         font-weight: 700;
@@ -96,7 +99,7 @@
     </header>
 
     <main class="flex-grow">
-        <section class="text-center py-20 px-6 bg-cover bg-center" style="background-image: linear-gradient(rgba(18,18,18,0.85), rgba(18,18,18,0.85)), url('https://placehold.co/1600x900/101010/1DB954?text=CED+BRASIL+Afiliados');">
+        <section class="text-center py-20 px-6 bg-cover bg-center keep-colors" style="background-image: linear-gradient(rgba(18,18,18,0.85), rgba(18,18,18,0.85)), url('https://placehold.co/1600x900/101010/1DB954?text=CED+BRASIL+Afiliados');">
             <h1 class="section-title">Torne-se um <span class="spotify-green">Afiliado Oficial</span></h1>
             <p class="section-subtitle">Ganhe dinheiro como afiliado, Vendendo nossos cursos profissionalizantes sem necessidade de estoque ou investimento, com certificado válido em todo o Brasil – totalmente gratuito.</p>
             <a href="https://dashboard.kiwify.com/join/affiliate/zhTcssre" class="inline-block bg-spotify-green text-black font-bold px-8 py-4 rounded-full text-xl hover-bg-spotify-green-darker transition shadow-lg">Quero Me Tornar Afiliado/a</a>
@@ -187,7 +190,7 @@
                         </div>
                     </div>
                     <div class="card flex items-start space-x-4">
-                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAA8CAMAAAAUhQWjAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAJGUExURQAAAB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VP///7HrK5EAAADAdFJOUwC8hJygRqbc9FybYOq5rD3GugYJEAoB+kwPLxQsZvyz4FHAbs6AuGT2EYEDGiOT+bCMTh3Lgthl1UUC70oVfIaSPjI4tGeWqBeINPsNeuSZ0cn3UFTpWY7KdhZPDPNpIdruO/7Hp7bo4ipv3fWFBUL9H83TG4+xHkORPPgI0jXBTfB3fr7mBCgONqK/8lJieON9WDpq5Se7JiLQOedobYfCKy4/qnSfxDDr7DGDcO0HKa6NJWxB30i9eZ0YVlpTrVZYP/YAAAABYktHRMFkZu9uAAAAB3RJTUUH6QYFFgkd727tKgAAA8lJREFUaN7tmPlfVGUUh08qbgnoAJaBo5Vb4kKrORoqaiVQakWhhYaWWIq5goW5pZiGZrkr5Za2m5bZ4tLzp3XuNncGZgb6NN3b1Pv95X4573tfznPvyznvRcTIyMjIyMjIyMjI6H+gu6BPt2Bf6NeLe5Om5fUfMBAYlOsgg3GU6yB3K8OQ/IKCgsIcBxkKwyJhMaQHKSouLunFvf604ffAvaFypAb5yxqhO+u+/wJIqYKU/XtARkZhlLVZvM0/CEa7Y/drqg+4/kEYI/60MnyNHadLJCw/HiY8FDTIRE2kb3lChjJJI5OdwSlqpxY5vgIeTgfyCEQf9Zd/rHdlI5sg5ZoWjzvBeDl6AqY5oSetNKfbNjYDZiZMe6qycpYOzq5UzYmNhonx1as0PjdYkJJ5+ijnSxeQp+EZ2zyrWwQW2L4aamqTpiX+jTwHz5d7qy+ERcFweCCli+GFF71gPMOXoM42L8MrNdTbfgkMTZ6WCLJ0KrzqrvNaAywLFGT569C4Ih6MZ1i60k1QTyBz3iA6wvLjvN2YEkTehFWunQ8NtUGCVDXB6rf8oJ/hInjbuq5hbaTZedTr9Gz4TgaQQli/wbEbYWFAHDZInu6ATZsTgn6GW6BFL62QL1vhXfXvQdu2DCDyvvfGtmu0KkCQjXq+2FGcGPQz3Am7yu0z4W7Z1sYmDX0Ae7pOSwJZBnvb3fH6oDgsEFXNvqSgn+GH2iP3ixyAapGPYKnIDqjMCFLbAQete3UPHgoSZI/+wtWTU4NIPXwscpgZMZFP4FMpaoMjGUGsop2vl6P6Nntz9swaSJ9CfYTHjqcGWQAn5CRUqF8Bg2W6VqL2zCDa6leeEjkNUwLjcKrWmV3QmbJqSZ52wshn8Ln69gbWyFm/uqYDkXNwVuZq7HzAIFLdqB94F1KBlGh/u/iFm9Iq2KCd81JPINo+m9Zdhi+D4/A6+1dfwzffpgCxnu53Q+i0/SX4PuqX1LQgEe1L09YG+wHvnbXK6rS3b08BomfiTuhv+yrbN8Z6ApFm+2h25YcQQOTqXi0yZ7qDXLTr83jbx65Y/po3lB6kNWpN/DFAjoTvkZ8OQ0dhN5DIBCun5c4P1yx/vWcQabEmngwHRE7pp8TAn7uCyAlN6Ybrr1v5xctbBpBfNPBrkBxJn7qtA3Rr53UF+U1z+t31V9U3xUcygNzUwK1AQf4hLbEKcNhJZEExfbfNYSeRDd1O/hdEzuq8dpvLYSfxd7W5omWxdpGOnH8h++wGGr0Tdh7ZAFlf98f+sNMwMjIyMjIyMsq2/gTGChpUaM2YMAAAAABJRU5ErkJggg==" alt="Logo da Kiwify" class="w-8 h-8 mt-1 no-invert" />
+                        <img src="kiwify.png" alt="Logo da Kiwify" class="w-8 h-8 mt-1 no-invert" />
                         <div>
                             <h3 class="text-xl font-semibold mb-2">Parceria direta com a Kiwify</h3>
                             <p class="text-gray-400 text-sm">Venda com segurança usando a estrutura da Kiwify para processar pagamentos e oferecer suporte especializado.</p>

--- a/parceiros.html
+++ b/parceiros.html
@@ -35,6 +35,9 @@
       body.light-theme img.no-invert {
         filter: none !important;
       }
+      body.light-theme .keep-colors {
+        filter: invert(1) hue-rotate(180deg);
+      }
       .section-title {
         font-size: 2.8rem;
         font-weight: 700;
@@ -96,7 +99,7 @@
     </header>
 
     <main class="flex-grow">
-        <section class="text-center py-20 px-6 bg-cover bg-center" style="background-image: linear-gradient(rgba(18,18,18,0.85), rgba(18,18,18,0.85)), url('https://placehold.co/1600x900/101010/1DB954?text=CED+BRASIL+Afiliados');">
+        <section class="text-center py-20 px-6 bg-cover bg-center keep-colors" style="background-image: linear-gradient(rgba(18,18,18,0.85), rgba(18,18,18,0.85)), url('https://placehold.co/1600x900/101010/1DB954?text=CED+BRASIL+Afiliados');">
             <h1 class="section-title">Torne-se um <span class="spotify-green">Parceiro Oficial</span></h1>
             <p class="section-subtitle">Ganhe dinheiro como afiliado, Vendendo nossos cursos profissionalizantes sem necessidade de estoque ou investimento, com certificado válido em todo o Brasil – totalmente gratuito.</p>
             <a href="https://dashboard.kiwify.com/join/affiliate/zhTcssre" class="inline-block bg-spotify-green text-black font-bold px-8 py-4 rounded-full text-xl hover-bg-spotify-green-darker transition shadow-lg">Quero Me Tornar Parceiro/a</a>
@@ -187,7 +190,7 @@
                         </div>
                     </div>
                     <div class="card flex items-start space-x-4">
-                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAA8CAMAAAAUhQWjAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAJGUExURQAAAB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VB25VP///7HrK5EAAADAdFJOUwC8hJygRqbc9FybYOq5rD3GugYJEAoB+kwPLxQsZvyz4FHAbs6AuGT2EYEDGiOT+bCMTh3Lgthl1UUC70oVfIaSPjI4tGeWqBeINPsNeuSZ0cn3UFTpWY7KdhZPDPNpIdruO/7Hp7bo4ipv3fWFBUL9H83TG4+xHkORPPgI0jXBTfB3fr7mBCgONqK/8lJieON9WDpq5Se7JiLQOedobYfCKy4/qnSfxDDr7DGDcO0HKa6NJWxB30i9eZ0YVlpTrVZYP/YAAAABYktHRMFkZu9uAAAAB3RJTUUH6QYFFgkd727tKgAAA8lJREFUaN7tmPlfVGUUh08qbgnoAJaBo5Vb4kKrORoqaiVQakWhhYaWWIq5goW5pZiGZrkr5Za2m5bZ4tLzp3XuNncGZgb6NN3b1Pv95X4573tfznPvyznvRcTIyMjIyMjIyMjI6H+gu6BPt2Bf6NeLe5Om5fUfMBAYlOsgg3GU6yB3K8OQ/IKCgsIcBxkKwyJhMaQHKSouLunFvf604ffAvaFypAb5yxqhO+u+/wJIqYKU/XtARkZhlLVZvM0/CEa7Y/drqg+4/kEYI/60MnyNHadLJCw/HiY8FDTIRE2kb3lChjJJI5OdwSlqpxY5vgIeTgfyCEQf9Zd/rHdlI5sg5ZoWjzvBeDl6AqY5oSetNKfbNjYDZiZMe6qycpYOzq5UzYmNhonx1as0PjdYkJJ5+ijnSxeQp+EZ2zyrWwQW2L4aamqTpiX+jTwHz5d7qy+ERcFweCCli+GFF71gPMOXoM42L8MrNdTbfgkMTZ6WCLJ0KrzqrvNaAywLFGT569C4Ih6MZ1i60k1QTyBz3iA6wvLjvN2YEkTehFWunQ8NtUGCVDXB6rf8oJ/hInjbuq5hbaTZedTr9Gz4TgaQQli/wbEbYWFAHDZInu6ATZsTgn6GW6BFL62QL1vhXfXvQdu2DCDyvvfGtmu0KkCQjXq+2FGcGPQz3Am7yu0z4W7Z1sYmDX0Ae7pOSwJZBnvb3fH6oDgsEFXNvqSgn+GH2iP3ixyAapGPYKnIDqjMCFLbAQete3UPHgoSZI/+wtWTU4NIPXwscpgZMZFP4FMpaoMjGUGsop2vl6P6Nntz9swaSJ9CfYTHjqcGWQAn5CRUqF8Bg2W6VqL2zCDa6leeEjkNUwLjcKrWmV3QmbJqSZ52wshn8Ln69gbWyFm/uqYDkXNwVuZq7HzAIFLdqB94F1KBlGh/u/iFm9Iq2KCd81JPINo+m9Zdhi+D4/A6+1dfwzffpgCxnu53Q+i0/SX4PuqX1LQgEe1L09YG+wHvnbXK6rS3b08BomfiTuhv+yrbN8Z6ApFm+2h25YcQQOTqXi0yZ7qDXLTr83jbx65Y/po3lB6kNWpN/DFAjoTvkZ8OQ0dhN5DIBCun5c4P1yx/vWcQabEmngwHRE7pp8TAn7uCyAlN6Ybrr1v5xctbBpBfNPBrkBxJn7qtA3Rr53UF+U1z+t31V9U3xUcygNzUwK1AQf4hLbEKcNhJZEExfbfNYSeRDd1O/hdEzuq8dpvLYSfxd7W5omWxdpGOnH8h++wGGr0Tdh7ZAFlf98f+sNMwMjIyMjIyMsq2/gTGChpUaM2YMAAAAABJRU5ErkJggg==" alt="Logo da Kiwify" class="w-8 h-8 mt-1 no-invert" />
+                        <img src="kiwify.png" alt="Logo da Kiwify" class="w-8 h-8 mt-1 no-invert" />
                         <div>
                             <h3 class="text-xl font-semibold mb-2">Parceria direta com a Kiwify</h3>
                             <p class="text-gray-400 text-sm">Venda com segurança usando a estrutura da Kiwify para processar pagamentos e oferecer suporte especializado.</p>


### PR DESCRIPTION
## Summary
- reference `kiwify.png` logo instead of embedded base64 image
- add `.keep-colors` style for light theme
- keep original colors on hero sections for Afiliados and Parceiros pages

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684353e02f888326ab878400ec3f51e2