### PR TITLE
Exibe cursos via API e envia seleção na matrícula

### DIFF
--- a/index.html
+++ b/index.html
@@ -427,7 +427,7 @@
         scrollBtn.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
         
         // Course Data and Filtering
-        const courses = [
+        const defaultCourses = [
             { name: "Desenvolvimento de Apps Mobile", category: "tecnologia", duration: "12 meses" },
             { name: "Ciência de Dados para Iniciantes", category: "tecnologia", duration: "10 meses" },
             { name: "Marketing de Mídias Sociais", category: "administracao", duration: "6 meses" },
@@ -446,6 +446,28 @@
             { name: "Marketing Digital", category: "administracao", duration: "8 meses" },
             { name: "Pacote Office", category: "tecnologia", duration: "6 meses" }
         ];
+
+        let courses = [];
+
+        const guessCategory = (name) => {
+            const lower = name.toLowerCase();
+            if (lower.includes('ingl')) return 'idiomas';
+            if (lower.includes('design')) return 'design';
+            if (lower.includes('marketing') || lower.includes('admin')) return 'administracao';
+            return 'tecnologia';
+        };
+
+        const fetchCourses = async () => {
+            try {
+                const res = await fetch('https://api.cedbrasilia.com.br/cursos');
+                const data = await res.json();
+                const nomes = Object.keys(data.cursos || {});
+                courses = nomes.map(n => ({ name: n, category: guessCategory(n), duration: '-' }));
+            } catch (err) {
+                courses = defaultCourses;
+            }
+            renderCourses();
+        };
 
         const courseListContainer = document.getElementById('course-list');
         const filterButtons = document.querySelectorAll('[data-filter]');
@@ -493,7 +515,7 @@
         
         // Initial Render
         document.querySelector('[data-filter="all"]').classList.add('active-filter', 'bg-spotify-green', 'text-black');
-        renderCourses();
+        fetchCourses();
     });
 </script>
 

--- a/matricularassas.js
+++ b/matricularassas.js
@@ -41,8 +41,31 @@ document.addEventListener('DOMContentLoaded', () => {
   const nomeInput = document.getElementById('nome');
   const cpfInput = document.getElementById('cpf');
   const phoneInput = document.getElementById('phone');
+  const coursesSelect = document.getElementById('courses');
   const formMessage = document.getElementById('form-message');
   const submitButton = document.getElementById('submitButton');
+
+  const loadCourses = async () => {
+    try {
+      const res = await fetch('https://api.cedbrasilia.com.br/cursos');
+      const data = await res.json();
+      const nomes = Object.keys(data.cursos || {});
+      nomes.forEach(n => {
+        const opt = document.createElement('option');
+        opt.value = n;
+        opt.textContent = n;
+        coursesSelect.appendChild(opt);
+      });
+    } catch (err) {
+      ['Excel PRO','Design Gráfico','Administração'].forEach(n => {
+        const opt = document.createElement('option');
+        opt.value = n;
+        opt.textContent = n;
+        coursesSelect.appendChild(opt);
+      });
+    }
+  };
+  loadCourses();
 
   nomeInput.addEventListener('input', () => validateField(nomeInput));
   cpfInput.addEventListener('input', (e) => {
@@ -71,6 +94,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const nome = nomeInput.value.trim();
     const cpf = cpfInput.value.replace(/\D/g, '').slice(0,11);
     const phone = phoneInput.value.replace(/\D/g, '');
+    const cursos = Array.from(coursesSelect.selectedOptions).map(o => o.value);
+    if (cursos.length === 0) {
+      formMessage.textContent = 'Selecione ao menos um curso.';
+      formMessage.className = 'text-center error-message';
+      return;
+    }
 
     submitButton.disabled = true;
     submitButton.textContent = 'Enviando...';
@@ -81,7 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch('https://api.cedbrasilia.com.br/matricularasaas', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nome, cpf, phone })
+        body: JSON.stringify({ nome, cpf, phone, cursos })
       });
       if (!res.ok) throw new Error('Falha ao conectar');
       window.location.href = 'https://www.asaas.com/c/dnbrk5s1xcf5zo1q';

--- a/matricularassas/index.html
+++ b/matricularassas/index.html
@@ -344,6 +344,12 @@
                     <label for="phone">Telefone (com DDD)</label>
                     <input type="tel" id="phone" name="phone" placeholder="(XX) XXXXX-XXXX" required aria-label="Número de Telefone">
                 </div>
+                <div class="form-group">
+                    <label for="courses">Cursos desejados</label>
+                    <select id="courses" name="courses" multiple required aria-label="Cursos" class="h-32 overflow-y-auto">
+                        <!-- opções serão carregadas via JavaScript -->
+                    </select>
+                </div>
                 <button type="submit" id="submitButton" class="w-full bg-spotify-green text-black font-extrabold px-6 py-3 rounded-lg text-lg hover-bg-spotify-green-darker transition duration-300 shadow-lg transform hover:scale-105">
                     Pagar e Matricular <i class="fas fa-arrow-circle-right ml-2"></i>
                 </button>


### PR DESCRIPTION
## Summary
- fetch cursos da API no index.html e renderiza dinamicamente
- adiciona campo de cursos no formulário de matrícula
- carrega cursos na página de matrícula e envia seleção para a API

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_684a191af2688326ad92ad1adac87e5c