### PR TITLE
Fix nav underline width

### DIFF
--- a/index.html
+++ b/index.html
@@ -1063,8 +1063,11 @@
 
             function updateIndicator(el) {
                 if (!indicator || !el) return;
-                indicator.style.width = `${el.offsetWidth}px`;
-                indicator.style.left = `${el.offsetLeft}px`;
+                const span = el.querySelector('span');
+                const width = span ? span.offsetWidth : el.offsetWidth;
+                const left = el.offsetLeft + (el.offsetWidth - width) / 2;
+                indicator.style.width = `${width}px`;
+                indicator.style.left = `${left}px`;
             }
             
             // Função para simular o efeito de digitação


### PR DESCRIPTION
## Summary
- ensure the navigation indicator matches the text width

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_684c7e7db7708326a3fc8726993723e4