### PR TITLE
Ensure phone numbers use 55 prefix

### DIFF
--- a/sistema.html
+++ b/sistema.html
@@ -55,6 +55,11 @@
 <script>
 const api = "https://whatsapptest-stij.onrender.com";
 
+function formatNumero(numero) {
+  const n = String(numero || "").replace(/\D/g, "");
+  return n.startsWith("55") ? n : "55" + n;
+}
+
 async function atualizarStatus() {
   try {
     const r = await fetch(api + "/status");
@@ -99,7 +104,7 @@ async function adicionarNumero(numero) {
     const r = await fetch(api + "/add-number", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ numero })
+      body: JSON.stringify({ numero: formatNumero(numero) })
     });
     if (!r.ok) throw new Error();
     fb.textContent = "Número adicionado";
@@ -162,7 +167,7 @@ document.getElementById("connectBtn").addEventListener("click", conectar);
 
 document.getElementById("addNumberForm").addEventListener("submit", e => {
   e.preventDefault();
-  adicionarNumero(document.getElementById("numero").value.trim());
+  adicionarNumero(formatNumero(document.getElementById("numero").value.trim()));
   document.getElementById("numero").value = "";
 });
 

--- a/sistema/index.html
+++ b/sistema/index.html
@@ -229,6 +229,11 @@
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             let BASIC_B64 = '';
+
+            function formatNumero(numero) {
+                const n = String(numero || '').replace(/\D/g, '');
+                return n.startsWith('55') ? n : '55' + n;
+            }
             // Simulação da busca do .env, pode ser removido se não for usado.
             // fetch('../get.env').then(r => r.text()).then(t => {
             //     const m = t.match(/^BASIC_B64=(.*)$/m);
@@ -540,6 +545,7 @@
             }
 
             async function enviarCobranca(numero, data) {
+                numero = formatNumero(numero);
                 if (!numero) return alert('Número inválido');
                 const mensagem = `Olá! Sua cobrança vence em ${data}.`;
                 try {
@@ -590,7 +596,7 @@
                 wpSendStatus.textContent = 'Processando...';
                 wpSendStatus.className = 'mt-4 text-gray-300';
                 try {
-                    const numeros = await parseFile(file);
+                    const numeros = (await parseFile(file)).map(formatNumero);
                     const intervalo = parseInt(wpInterval.value, 10) * 1000;
                     for (let i = 0; i < numeros.length; i++) {
                         await fetch(`https://api.allorigins.win/raw?url=https://whatsapptest-stij.onrender.com/send?para=${numeros[i]}&mensagem=${encodeURIComponent(mensagem)}`);


### PR DESCRIPTION
## Summary
- add `formatNumero` helper to always prefix `55`
- use `formatNumero` when adding and sending WhatsApp numbers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f61002fac8326a215ce5695ad5cd9