### PR TITLE
Atualiza checkout de cursos

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,13 +737,16 @@
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
                 const data = await response.json();
-                const names = Object.keys(data.cursos || {}).filter(n => n !== 'None');
-                availableCourses = names.map(name => ({
-                    name,
-                    price: COURSE_PRICES[name] || 0,
-                    description: COURSE_DESCRIPTIONS[name] || 'Curso profissionalizante do CED BRASIL.',
-                    detail: COURSE_DETAILS[name] || COURSE_DESCRIPTIONS[name] || ''
-                }));
+                const cursosObj = data.cursos || {};
+                availableCourses = Object.entries(cursosObj)
+                    .filter(([n]) => n !== 'None')
+                    .map(([name, ids]) => ({
+                        name,
+                        ids,
+                        price: COURSE_PRICES[name] || 0,
+                        description: COURSE_DESCRIPTIONS[name] || 'Curso profissionalizante do CED BRASIL.',
+                        detail: COURSE_DETAILS[name] || COURSE_DESCRIPTIONS[name] || ''
+                    }));
                 availableCourses.sort((a, b) => {
                     if (a.name === 'Pacote Office') return -1;
                     if (b.name === 'Pacote Office') return 1;
@@ -794,8 +797,9 @@
             // Adiciona listeners de evento para botões "Me matricular agora!"
             document.querySelectorAll(".enroll-course").forEach(button => {
                 button.addEventListener("click", e => {
-                    selectedCourse = e.target.dataset.courseName;
-                    if (selectedCourseInput) selectedCourseInput.value = selectedCourse;
+                    const courseName = e.target.dataset.courseName;
+                    selectedCourse = availableCourses.find(c => c.name === courseName);
+                    if (selectedCourseInput) selectedCourseInput.value = courseName;
                     if (loginInfo) loginInfo.innerHTML = "";
                     openCheckout();
                 });
@@ -1100,6 +1104,23 @@
                 return num;
             }
 
+            async function gerarLinkPagamento(dadosAluno) {
+                const resposta = await fetch('https://api.cedbrasilia.com.br/asaas/checkout', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(dadosAluno)
+                });
+
+                if (!resposta.ok) {
+                    throw new Error('Falha ao gerar cobrança');
+                }
+
+                const json = await resposta.json();
+                if (json.url) {
+                    window.location.href = json.url;
+                }
+            }
+
             if (checkoutButton) checkoutButton.addEventListener('click', () => {
                 openCheckout();
             });
@@ -1122,29 +1143,17 @@
                 checkoutMsg.textContent = 'Enviando...';
                 checkoutMsg.className = 'text-center text-gray-300 mt-2 h-5';
                 try {
-                    const res = await fetch('https://api.cedbrasilia.com.br/matricular', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ nome, cpf, whatsapp: phone, cursos: [selectedCourse] })
-                    });
-                    if (res.ok) {
-                        const data = await res.json();
-                        checkoutMsg.textContent = "Matrícula enviada com sucesso!";
-                        checkoutMsg.className = "text-center text-green-400 mt-2 h-5";
-                        checkoutForm.reset();
-                        if (data.usuario && data.senha) {
-                            loginInfo.innerHTML = `Usuário: <strong>${data.usuario}</strong><br>Senha: <strong>${data.senha}</strong><br>`;
-                            const link = document.createElement("a");
-                            link.href = `https://api.cedbrasilia.com.br/login/?usuario=${encodeURIComponent(data.usuario)}&senha=${encodeURIComponent(data.senha)}`;
-                            link.className = "button-glow bg-spotify-green text-black font-bold py-2 px-4 rounded-full mt-2 inline-block";
-                            link.textContent = "ENTRAR";
-                            loginInfo.appendChild(link);
-                        }
-                    } else {
-                        throw new Error('Erro ao enviar');
-                    }
-                } catch {
-                    checkoutMsg.textContent = 'Erro ao enviar. Tente novamente.';
+                    const dados = {
+                        nome,
+                        cpf,
+                        whatsapp: phone,
+                        valor: selectedCourse ? selectedCourse.price : 0,
+                        descricao: selectedCourse ? selectedCourse.name : '',
+                        cursos_ids: selectedCourse ? selectedCourse.ids : []
+                    };
+                    await gerarLinkPagamento(dados);
+                } catch (err) {
+                    checkoutMsg.textContent = err.message || 'Erro ao enviar. Tente novamente.';
                     checkoutMsg.className = 'text-center text-red-500 mt-2 h-5';
                 }
             });


### PR DESCRIPTION
## Summary
- integrar busca de IDs de cursos pelo backend
- ajustar seleção de curso para usar objeto completo
- adicionar função `gerarLinkPagamento` que chama `/asaas/checkout`
- enviar dados do checkout para gerar link de pagamento

## Testing
- `curl -s https://api.cedbrasilia.com.br/cursos | head`

------
https://chatgpt.com/codex/tasks/task_e_684fb9a061748326a32548050074e9f5