### PR TITLE
Add course-specific checkout pages

### DIFF
--- a/course-form.js
+++ b/course-form.js
@@ -1,0 +1,117 @@
+const COURSE_PRICES = {
+  "Excel PRO": 49.90,
+  "Design Gráfico": 89.90,
+  "Analista e Desenvolvimento de Sistemas": 79.90,
+  "Administração": 49.90,
+  "Inglês Fluente": 99.90,
+  "Inglês Kids": 39.90,
+  "Informática Essencial": 49.90,
+  "Operador de Micro": 59.90,
+  "Especialista em Marketing & Vendas 360º": 149.90,
+  "Marketing Digital": 89.90,
+  "Pacote Office": 29.99,
+};
+
+function applyCPFMask(v) {
+  v = v.replace(/\D/g, '').slice(0,11);
+  v = v.replace(/(\d{3})(\d)/, '$1.$2');
+  v = v.replace(/(\d{3})(\d)/, '$1.$2');
+  v = v.replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+  return v;
+}
+
+function applyWhatsappMask(value) {
+  value = value.replace(/\D/g, '');
+  if (value.length > 11) value = value.slice(0, 11);
+  if (value.length > 10) {
+    return `(${value.slice(0,2)}) ${value.slice(2,7)}-${value.slice(7)}`;
+  } else if (value.length > 6) {
+    return `(${value.slice(0,2)}) ${value.slice(2,6)}-${value.slice(6)}`;
+  } else if (value.length > 2) {
+    return `(${value.slice(0,2)}) ${value.slice(2)}`;
+  } else {
+    return value;
+  }
+}
+
+function normalizarNumero(num) {
+  num = String(num || '').replace(/\D/g, '');
+  if (!num.startsWith('55')) num = '55' + num;
+  if (num.startsWith('55') && num[4] === '9') {
+    num = num.slice(0,4) + num.slice(5);
+  }
+  return num;
+}
+
+async function gerarLinkPagamento(dadosAluno) {
+  const resposta = await fetch('https://api.cedbrasilia.com.br/asaas/checkout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dadosAluno)
+  });
+
+  if (!resposta.ok) {
+    throw new Error('Falha ao gerar cobrança');
+  }
+
+  const json = await resposta.json();
+  if (json.url) {
+    window.location.href = json.url;
+  }
+}
+
+async function obterIdsCurso(nome) {
+  try {
+    const res = await fetch('https://api.cedbrasilia.com.br/cursos');
+    const data = await res.json();
+    return (data.cursos && data.cursos[nome]) ? data.cursos[nome] : [];
+  } catch (_) {
+    return [];
+  }
+}
+
+function initCoursePage(courseName) {
+  document.addEventListener('DOMContentLoaded', async () => {
+    document.getElementById('currentYear').textContent = new Date().getFullYear();
+    document.getElementById('course-title').textContent = courseName;
+    const price = COURSE_PRICES[courseName] || 0;
+    const priceEl = document.getElementById('course-price');
+    if (priceEl) priceEl.textContent = price ? 'R$ ' + price.toFixed(2).replace('.', ',') : '';
+    const courseIds = await obterIdsCurso(courseName);
+
+    const nomeInput = document.getElementById('nome');
+    const cpfInput = document.getElementById('cpf');
+    const phoneInput = document.getElementById('whatsapp');
+    const message = document.getElementById('form-message');
+
+    cpfInput.addEventListener('input', e => { e.target.value = applyCPFMask(e.target.value); });
+    phoneInput.addEventListener('input', e => { e.target.value = applyWhatsappMask(e.target.value); });
+
+    document.getElementById('enrollmentForm').addEventListener('submit', async e => {
+      e.preventDefault();
+      const nome = nomeInput.value.trim();
+      const cpf = cpfInput.value.replace(/\D/g, '').slice(0,11);
+      const phone = normalizarNumero(phoneInput.value);
+      if (!nome || !cpf || !phone) {
+        message.textContent = 'Preencha todos os campos.';
+        message.className = 'text-center text-red-500 mt-2 h-5';
+        return;
+      }
+      message.textContent = 'Enviando...';
+      message.className = 'text-center text-gray-300 mt-2 h-5';
+      try {
+        await gerarLinkPagamento({
+          nome,
+          cpf,
+          whatsapp: phone,
+          valor: price,
+          descricao: courseName,
+          cursos_ids: courseIds
+        });
+      } catch (err) {
+        message.textContent = err.message || 'Erro ao enviar. Tente novamente.';
+        message.className = 'text-center text-red-500 mt-2 h-5';
+      }
+    });
+  });
+}

--- a/cursos/administracao.html
+++ b/cursos/administracao.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Administração</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Administração</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Administração');</script>
+</body>
+</html>

--- a/cursos/analista-e-desenvolvimento-de-sistemas.html
+++ b/cursos/analista-e-desenvolvimento-de-sistemas.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Analista e Desenvolvimento de Sistemas</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Analista e Desenvolvimento de Sistemas</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Analista e Desenvolvimento de Sistemas');</script>
+</body>
+</html>

--- a/cursos/design-grafico.html
+++ b/cursos/design-grafico.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Design Gráfico</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Design Gráfico</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Design Gráfico');</script>
+</body>
+</html>

--- a/cursos/especialista-em-marketing-vendas-360.html
+++ b/cursos/especialista-em-marketing-vendas-360.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Especialista em Marketing & Vendas 360º</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Especialista em Marketing & Vendas 360º</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Especialista em Marketing & Vendas 360º');</script>
+</body>
+</html>

--- a/cursos/excel-pro.html
+++ b/cursos/excel-pro.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Excel PRO</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Excel PRO</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Excel PRO');</script>
+</body>
+</html>

--- a/cursos/informatica-essencial.html
+++ b/cursos/informatica-essencial.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Informática Essencial</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Informática Essencial</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Informática Essencial');</script>
+</body>
+</html>

--- a/cursos/ingles-fluente.html
+++ b/cursos/ingles-fluente.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Inglês Fluente</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Inglês Fluente</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Inglês Fluente');</script>
+</body>
+</html>

--- a/cursos/ingles-kids.html
+++ b/cursos/ingles-kids.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Inglês Kids</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Inglês Kids</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Inglês Kids');</script>
+</body>
+</html>

--- a/cursos/marketing-digital.html
+++ b/cursos/marketing-digital.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Marketing Digital</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Marketing Digital</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Marketing Digital');</script>
+</body>
+</html>

--- a/cursos/operador-de-micro.html
+++ b/cursos/operador-de-micro.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Operador de Micro</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Operador de Micro</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Operador de Micro');</script>
+</body>
+</html>

--- a/cursos/pacote-office.html
+++ b/cursos/pacote-office.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="pt-BR" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CED BRASIL - Pacote Office</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="../style.css">
+  <link rel="icon" href="../favicon.jpg" type="image/jpeg" />
+</head>
+<body class="overflow-x-hidden">
+<header class="bg-[#121212] py-4 sticky top-0 z-50 shadow-lg shadow-black/20">
+  <div class="container mx-auto px-6 flex justify-between items-center">
+    <a href="../index.html"><img src="../ced.svg" alt="CED Brasil" class="h-16 inline-block"></a>
+    <a href="../index.html" class="bg-gray-800 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded-lg transition-colors">Voltar ao Início</a>
+  </div>
+</header>
+<main class="flex justify-center py-10">
+  <div class="card w-full max-w-md">
+    <h1 id="course-title" class="text-3xl md:text-4xl font-bold text-center mb-2">Pacote Office</h1>
+    <p id="course-price" class="text-center text-xl font-semibold spotify-green mb-6"></p>
+    <p class="text-gray-400 text-center mb-6">Preencha seus dados para gerar o link de pagamento.</p>
+    <form id="enrollmentForm" class="space-y-4">
+      <div>
+        <label for="nome" class="block mb-2 font-semibold">Nome completo</label>
+        <input type="text" id="nome" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="cpf" class="block mb-2 font-semibold">CPF</label>
+        <input type="text" id="cpf" placeholder="000.000.000-00" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div>
+        <label for="whatsapp" class="block mb-2 font-semibold">WhatsApp (com DDD)</label>
+        <input type="tel" id="whatsapp" placeholder="(XX) XXXXX-XXXX" required class="w-full p-3 rounded-lg text-white bg-gray-800 border border-gray-600" />
+      </div>
+      <div id="form-message" class="text-center mt-2 h-5"></div>
+      <button type="submit" class="w-full button-glow bg-spotify-green text-black font-bold py-3 px-6 rounded-full hover-bg-spotify-green-darker">Concluir Matrícula</button>
+    </form>
+  </div>
+</main>
+<footer class="text-center py-8 border-t border-gray-800 mt-auto">
+  <div class="container mx-auto px-6">
+    <div class="text-2xl font-bold tracking-tighter mb-4 text-white">
+      <a href="../index.html">CED <span class="spotify-green">BRASIL</span></a>
+    </div>
+    <p class="text-gray-400">&copy; <span id="currentYear"></span> CED BRASIL. Todos os direitos reservados.</p>
+  </div>
+</footer>
+<script src="../course-form.js"></script>
+<script>initCoursePage('Pacote Office');</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable `course-form.js` with helper functions
- create course enrollment pages under `cursos/`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fcb96c46083268e79c32fb7e1d582