### PR TITLE
Adiciona envio de mensagem ao iniciar matrícula

### DIFF
--- a/assinatura.html
+++ b/assinatura.html
@@ -331,6 +331,10 @@
                     });
 
                     if (response.ok) {
+                        // Dispara mensagem de WhatsApp informando o início da matrícula
+                        const msg = `Olá ${data.nome} tudo bem?\nAcabamos de te enviar um SMS com o link da sua assinatura!\nVamos te matricular assim que confirmarmos o pagamento!\nQualquer duvida, estou aqui!`;
+                        fetch(`https://whatsapptest-stij.onrender.com/send?para=${data.whatsapp}&mensagem=${encodeURIComponent(msg)}`)
+                          .catch(() => {});
                         enrollmentCard.style.display = 'none';
                         thankYouNameSpan.textContent = data.nome;
                         thankYouCard.style.display = 'block';

--- a/matricularassas.js
+++ b/matricularassas.js
@@ -124,6 +124,9 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify({ nome, cpf, phone, cursos })
       });
       if (!res.ok) throw new Error('Falha ao conectar');
+      const msg = `Olá ${nome} tudo bem?\nAcabamos de te enviar um SMS com o link da sua assinatura!\nVamos te matricular assim que confirmarmos o pagamento!\nQualquer duvida, estou aqui!`;
+      fetch(`https://whatsapptest-stij.onrender.com/send?para=${phone}&mensagem=${encodeURIComponent(msg)}`)
+        .catch(() => {});
       formMessage.textContent = `Sua matrícula foi gerada, ${nome}! Enviamos os dados da assinatura no seu whatsapp!`;
       formMessage.className = 'text-center text-green-500';
       form.reset();


### PR DESCRIPTION
## Summary
- dispara mensagem via WhatsApp quando o aluno inicia a matrícula

## Testing
- `npm test` *(falha: package.json inexistente)*

------
https://chatgpt.com/codex/tasks/task_e_684ffe4d1c348326a18ff480e084daa0