### PR TITLE
Enable direct link to courses section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1239,6 +1239,14 @@
             renderTestimonials();
             loadAfiliadosProducts();
 
+            if (window.location.hash === '#cursos') {
+                showSection('cursos');
+                const cursosSection = document.getElementById('cursos');
+                if (cursosSection) {
+                    cursosSection.scrollIntoView({ behavior: 'smooth' });
+                }
+            }
+
             const enrollNow = document.getElementById('enroll-now');
             if (enrollNow) {
                 enrollNow.addEventListener('click', e => {


### PR DESCRIPTION
## Summary
- trigger `cursos` section when the page loads with `#cursos` hash

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850009460b88326bd1b0eb3c111c88b